### PR TITLE
Potential fix for code scanning alert no. 70: Missing rate limiting

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -644,8 +644,13 @@ restoreOverwrittenFilesWithOriginals().then(() => {
 
   /* Routes for promotion video page */
   app.get('/promotion', promotionVideo())
-  app.get('/video', getVideo())
-
+  const videoLimiter = rateLimit({
+    windowMs: 5 * 60 * 1000, // 5 minutes
+    max: 20, // limit each IP to 20 requests per windowMs
+    standardHeaders: true, // return rate limit info in the `RateLimit-*` headers
+    legacyHeaders: false, // disable the `X-RateLimit-*` headers
+  });
+  app.get('/video', videoLimiter, getVideo())
   /* Routes for profile page */
   app.get('/profile', security.updateAuthenticatedUsers(), getUserProfile())
   app.post('/profile', updateUserProfile())


### PR DESCRIPTION
Potential fix for [https://github.com/kngo-dev/juice-shop/security/code-scanning/70](https://github.com/kngo-dev/juice-shop/security/code-scanning/70)

To address the issue, we will introduce a rate-limiting middleware specifically for the `/video` route. Using the `express-rate-limit` package (already imported as `rateLimit`), we will define a rate limiter configuration that limits the number of requests an individual client can make to this endpoint within a specified time window. This will prevent abuse and mitigate the risk of denial-of-service attacks.

Steps:
1. Define a new rate limiter instance for the `/video` route.
2. Apply this rate limiter as middleware to the `/video` route by passing it as a parameter before the `getVideo()` handler.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
